### PR TITLE
support JDK 1.6 and 1.7 on OSX

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
 		<spring.version>4.0.0.RC1</spring.version>
 		<spring-boot.version>0.5.0.M6</spring-boot.version>
 		<swagger.version>1.2.0</swagger.version>
+    <javatoolsjar>${java.home}/../lib/tools.jar</javatoolsjar>
 	</properties>
 
 	<dependencyManagement>
@@ -96,5 +97,18 @@
 			</snapshots>
 		</repository>
 	</repositories>
+    <profiles>
+        <profile>
+            <id>toolsjar-profile</id>
+            <activation>
+                <file>
+                    <missing>${javatoolsjar}</missing>
+                </file>
+            </activation>
+            <properties>
+                <javatoolsjar>${java.home}/../Classes/classes.jar</javatoolsjar>
+            </properties>
+        </profile>
+    </profiles>
 
 </project>

--- a/rest-documentation-core/pom.xml
+++ b/rest-documentation-core/pom.xml
@@ -20,7 +20,7 @@
 			<artifactId>tools</artifactId>
 			<version>0</version>
 			<scope>system</scope>
-			<systemPath>${java.home}/../lib/tools.jar</systemPath>
+			<systemPath>${javatoolsjar}</systemPath>
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>


### PR DESCRIPTION
This patch supports JDK 1.6 and 1.7 (on OSX as well as other OS)

It checks that the tools.jar can be found in the default location.
If not the old OSX "Classes.jar" is used
